### PR TITLE
Support startup commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "together-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libredox"
@@ -283,6 +283,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "posix"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577f547ca2212ae6b7024aa5f2c6a3a14e9cdccd68ef950ce49702be51fefd38"
 
 [[package]]
 name = "proc-macro2"
@@ -334,6 +340,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -438,6 +450,9 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "dirs",
+ "libc",
+ "posix",
+ "semver",
  "serde",
  "subprocess",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["execute", "process", "command", "cli", "interactive"]
 repository = "https://github.com/michaelblawrence/together-rs"
 
 [[bin]]
-name = "together"
+name = "together_tmp"
 path = "src/main.rs"
 
 [dependencies]
@@ -18,6 +18,9 @@ clap = { version = "4.4.18", features = ["derive"] }
 ctrlc = "3.4.2"
 dialoguer = "0.11.0"
 dirs = "5.0.1"
+libc = "0.2.153"
+posix = "0.0.2"
+semver = "1.0.22"
 serde = { version = "1.0.196", features = ["derive"] }
 subprocess = "0.2.9"
 toml = "0.8.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "together-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Michael Lawrence <mblawrence27@gmail.com>"]
@@ -10,7 +10,7 @@ keywords = ["execute", "process", "command", "cli", "interactive"]
 repository = "https://github.com/michaelblawrence/together-rs"
 
 [[bin]]
-name = "together_tmp"
+name = "together"
 path = "src/main.rs"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,19 +58,20 @@ fn run_command(context: RunContext) -> Result<(), errors::TogetherError> {
                     &sender,
                     &opts.commands,
                 )?;
-                let config = config::Config {
-                    run_opts: opts.clone(),
-                    running: commands
-                        .iter()
-                        .map(|&c| opts.commands.iter().position(|x| x == c).unwrap())
-                        .collect(),
-                    startup: startup_commands.as_ref().map(|commands| {
-                        commands
-                            .iter()
-                            .map(|c| opts.commands.iter().position(|x| x == c).unwrap())
-                            .collect()
-                    }),
-                };
+                let config = config::Config::new(&context, &commands);
+                // let config = config::Config {
+                //     run_opts: opts.clone(),
+                //     running: commands
+                //         .iter()
+                //         .map(|&c| opts.commands.iter().position(|x| x == c).unwrap())
+                //         .collect(),
+                //     startup: startup_commands.as_ref().map(|commands| {
+                //         commands
+                //             .iter()
+                //             .map(|c| opts.commands.iter().position(|x| x == c).unwrap())
+                //             .collect()
+                //     }),
+                // };
                 config::save(&config)?;
                 commands
             }
@@ -178,28 +179,8 @@ fn block_for_user_input(
             }
             "d" => {
                 let list = sender.list()?;
-                let running = list
-                    .iter()
-                    .map(|c| {
-                        context
-                            .opts
-                            .commands
-                            .iter()
-                            .position(|x| x == c.command())
-                            .unwrap()
-                    })
-                    .collect();
-
-                let config = config::Config {
-                    run_opts: context.opts.clone(),
-                    running,
-                    startup: context.startup_commands.as_ref().map(|commands| {
-                        commands
-                            .iter()
-                            .map(|c| context.opts.commands.iter().position(|x| x == c).unwrap())
-                            .collect()
-                    }),
-                };
+                let running: Vec<_> = list.iter().map(|c| c.command()).collect();
+                let config = config::Config::new(&context, &running);
                 config::dump(&config)?;
             }
             "k" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 use std::sync::{Arc, Mutex};
 
 use clap::Parser;
+use config::RunContext;
 use errors::TogetherResult;
 use manager::ProcessAction;
+
+use crate::manager::ProcessActionResponse;
 
 mod config;
 mod errors;
@@ -12,25 +15,27 @@ mod terminal;
 
 fn main() {
     let opts = terminal::Opts::parse();
-    let cwd = opts.working_directory.clone();
-    let (run_opts, selected_commands) = config::to_run_opts(opts);
-    let result = run_command(run_opts, selected_commands, cwd);
+    let context = config::to_run_context(opts);
+    let result = run_command(context);
     if let Err(e) = result {
         log_err!("Unexpected error: {}", e);
         std::process::exit(1);
     }
 }
 
-fn run_command(
-    opts: terminal::Run,
-    override_commands: Option<Vec<String>>,
-    working_directory: Option<String>,
-) -> Result<(), errors::TogetherError> {
+fn run_command(context: RunContext) -> Result<(), errors::TogetherError> {
+    let RunContext {
+        opts,
+        override_commands,
+        startup_commands,
+        working_directory,
+    } = &context;
+
     let manager = manager::ProcessManager::new()
         .with_raw_mode(opts.raw)
         .with_exit_on_error(opts.exit_on_error)
         .with_quit_on_completion(opts.quit_on_completion)
-        .with_working_directory(working_directory)
+        .with_working_directory(working_directory.to_owned())
         .start();
 
     let sender = manager.subscribe();
@@ -59,6 +64,12 @@ fn run_command(
                         .iter()
                         .map(|&c| opts.commands.iter().position(|x| x == c).unwrap())
                         .collect(),
+                    startup: startup_commands.as_ref().map(|commands| {
+                        commands
+                            .iter()
+                            .map(|c| opts.commands.iter().position(|x| x == c).unwrap())
+                            .collect()
+                    }),
                 };
                 config::save(&config)?;
                 commands
@@ -66,11 +77,33 @@ fn run_command(
         }
     };
 
+    if let Some(commands) = startup_commands {
+        log!("Running startup commands...");
+        for command in commands {
+            match sender.send(ProcessAction::Create(command.clone()))? {
+                ProcessActionResponse::Created(id) => {
+                    match sender.send(ProcessAction::Wait(id))? {
+                        ProcessActionResponse::Waited(done) => {
+                            done.recv()?;
+                            log!("Startup command '{}' completed", command);
+                        }
+                        _ => {
+                            log_err!("Unexpected response from process manager");
+                        }
+                    }
+                }
+                _ => {
+                    log_err!("Unexpected response from process manager");
+                }
+            }
+        }
+    }
+
     for command in selected_commands {
         sender.send(ProcessAction::Create(command.clone()))?;
     }
 
-    block_for_user_input(opts, sender)?;
+    block_for_user_input(&context, sender)?;
 
     std::mem::drop(manager);
     Ok(())
@@ -96,8 +129,8 @@ pub fn handle_ctrl_signal(sender: manager::ProcessManagerHandle) {
     handler.expect("Error setting Ctrl-C handler");
 }
 
-pub fn block_for_user_input(
-    opts: terminal::Run,
+fn block_for_user_input(
+    context: &RunContext,
     sender: manager::ProcessManagerHandle,
 ) -> Result<(), errors::TogetherError> {
     let mut input = String::new();
@@ -110,6 +143,7 @@ pub fn block_for_user_input(
 
                 println!();
                 println!("Press 't' to trigger a one-time run");
+                println!("Press 'b' to batch trigger a one-time run");
                 println!("Press 'k' to kill a running command");
                 println!("Press 'r' to restart a running command");
                 println!("Press 'l' to list all running commands");
@@ -123,6 +157,9 @@ pub fn block_for_user_input(
                 match sender.list() {
                     Ok(list) => {
                         println!("together is running {} commands in parallel:", list.len());
+                        for command in list {
+                            println!("  {}", command);
+                        }
                     }
                     Err(_) => {
                         println!("together is running in an unknown state");
@@ -143,12 +180,25 @@ pub fn block_for_user_input(
                 let list = sender.list()?;
                 let running = list
                     .iter()
-                    .map(|c| opts.commands.iter().position(|x| x == c.command()).unwrap())
+                    .map(|c| {
+                        context
+                            .opts
+                            .commands
+                            .iter()
+                            .position(|x| x == c.command())
+                            .unwrap()
+                    })
                     .collect();
 
                 let config = config::Config {
-                    run_opts: opts.clone(),
+                    run_opts: context.opts.clone(),
                     running,
+                    startup: context.startup_commands.as_ref().map(|commands| {
+                        commands
+                            .iter()
+                            .map(|c| context.opts.commands.iter().position(|x| x == c).unwrap())
+                            .collect()
+                    }),
                 };
                 config::dump(&config)?;
             }
@@ -179,9 +229,19 @@ pub fn block_for_user_input(
                 let command = select_single_command(
                     "Pick command to run, or press 'q' to cancel",
                     &sender,
-                    &opts.commands,
+                    &context.opts.commands,
                 )?;
                 if let Some(command) = command {
+                    sender.send(ProcessAction::Create(command.clone()))?;
+                }
+            }
+            "b" => {
+                let commands = select_multiple_commands(
+                    "Pick commands to run, or press 'q' to cancel",
+                    &sender,
+                    &context.opts.commands,
+                )?;
+                for command in commands {
                     sender.send(ProcessAction::Create(command.clone()))?;
                 }
             }
@@ -224,6 +284,9 @@ fn select_multiple_commands<'a>(
 ) -> TogetherResult<Vec<&'a String>> {
     sender.send(ProcessAction::SetMute(true))?;
     let commands = terminal::Terminal::select_multiple(prompt, list);
+    if commands.is_empty() {
+        log!("No commands selected...");
+    }
     sender.send(ProcessAction::SetMute(false))?;
     Ok(commands)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,13 +88,13 @@ fn run_command(context: RunContext) -> Result<(), errors::TogetherError> {
                             done.recv()?;
                             log!("Startup command '{}' completed", command);
                         }
-                        _ => {
-                            log_err!("Unexpected response from process manager");
+                        x => {
+                            log_err!("Unexpected response from process manager: {:?}", x);
                         }
                     }
                 }
-                _ => {
-                    log_err!("Unexpected response from process manager");
+                x => {
+                    log_err!("Unexpected response from process manager: {:?}", x);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ fn run_command(context: RunContext) -> Result<(), errors::TogetherError> {
         override_commands,
         startup_commands,
         working_directory,
+        config_path,
     } = &context;
 
     let manager = manager::ProcessManager::new()
@@ -59,20 +60,7 @@ fn run_command(context: RunContext) -> Result<(), errors::TogetherError> {
                     &opts.commands,
                 )?;
                 let config = config::Config::new(&context, &commands);
-                // let config = config::Config {
-                //     run_opts: opts.clone(),
-                //     running: commands
-                //         .iter()
-                //         .map(|&c| opts.commands.iter().position(|x| x == c).unwrap())
-                //         .collect(),
-                //     startup: startup_commands.as_ref().map(|commands| {
-                //         commands
-                //             .iter()
-                //             .map(|c| opts.commands.iter().position(|x| x == c).unwrap())
-                //             .collect()
-                //     }),
-                // };
-                config::save(&config)?;
+                config::save(&config, config_path.as_deref())?;
                 commands
             }
         }
@@ -238,36 +226,30 @@ fn block_for_user_input(
 
 fn select_single_process<'a>(
     prompt: &'a str,
-    sender: &'a manager::ProcessManagerHandle,
+    _sender: &'a manager::ProcessManagerHandle,
     list: &'a [process::ProcessId],
 ) -> TogetherResult<Option<&'a process::ProcessId>> {
-    sender.send(ProcessAction::SetMute(true))?;
     let command = terminal::Terminal::select_single(prompt, list);
-    sender.send(ProcessAction::SetMute(false))?;
     Ok(command)
 }
 
 fn select_single_command<'a>(
     prompt: &'a str,
-    sender: &'a manager::ProcessManagerHandle,
+    _sender: &'a manager::ProcessManagerHandle,
     list: &'a [String],
 ) -> TogetherResult<Option<&'a String>> {
-    sender.send(ProcessAction::SetMute(true))?;
     let command = terminal::Terminal::select_single(prompt, list);
-    sender.send(ProcessAction::SetMute(false))?;
     Ok(command)
 }
 
 fn select_multiple_commands<'a>(
     prompt: &'a str,
-    sender: &'a manager::ProcessManagerHandle,
+    _sender: &'a manager::ProcessManagerHandle,
     list: &'a [String],
 ) -> TogetherResult<Vec<&'a String>> {
-    sender.send(ProcessAction::SetMute(true))?;
     let commands = terminal::Terminal::select_multiple(prompt, list);
     if commands.is_empty() {
         log!("No commands selected...");
     }
-    sender.send(ProcessAction::SetMute(false))?;
     Ok(commands)
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -15,6 +15,7 @@ pub enum ProcessAction {
     SetMute(bool),
 }
 
+#[derive(Debug)]
 pub enum ProcessActionResponse {
     Created(ProcessId),
     Waited(mpsc::Receiver<()>),

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -12,7 +12,6 @@ pub enum ProcessAction {
     Kill(ProcessId),
     KillAll,
     List,
-    SetMute(bool),
 }
 
 #[derive(Debug)]
@@ -23,7 +22,6 @@ pub enum ProcessActionResponse {
     KilledAll,
     List(Vec<ProcessId>),
     Error(ProcessManagerError),
-    MuteSet,
 }
 
 #[derive(Debug)]
@@ -210,16 +208,6 @@ impl ProcessManager {
             ProcessAction::List => {
                 let list = self.processes.keys().cloned().collect();
                 ProcessActionResponse::List(list)
-            }
-            ProcessAction::SetMute(mute) => {
-                for (_, child) in self.processes.iter_mut() {
-                    if mute {
-                        child.mute();
-                    } else {
-                        child.unmute();
-                    }
-                }
-                ProcessActionResponse::MuteSet
             }
         }
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -77,14 +77,6 @@ mod subprocess_impl {
             })
         }
 
-        pub fn mute(&self) {
-            // TODO: remove
-        }
-
-        pub fn unmute(&self) {
-            // TODO: remove
-        }
-
         pub fn kill(&mut self) -> TogetherResult<()> {
             fn check_err<T: Ord + Default>(num: T) -> std::io::Result<T> {
                 if num < T::default() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -32,7 +32,7 @@ mod subprocess_impl {
         sync::{Arc, RwLock},
     };
 
-    use subprocess::{Exec, ExitStatus};
+    use subprocess::{unix::PopenExt, Exec, ExitStatus};
 
     use crate::{
         errors::{TogetherInternalError, TogetherResult},
@@ -76,21 +76,22 @@ mod subprocess_impl {
         }
 
         pub fn mute(&self) {
-            log!("Muting process {}", self.popen.pid().unwrap());
-            if let Some(mute) = &self.mute {
-                *mute.write().unwrap() = true;
-            }
+            // TODO: remove
         }
 
         pub fn unmute(&self) {
-            log!("Unmuting process {}", self.popen.pid().unwrap());
-            if let Some(mute) = &self.mute {
-                *mute.write().unwrap() = false;
-            }
+            // TODO: remove
         }
 
         pub fn kill(&mut self) -> TogetherResult<()> {
-            Ok(self.popen.terminate()?)
+            #[cfg(windows)]
+            {
+                Ok(self.popen.terminate()?)
+            }
+            #[cfg(unix)]
+            {
+                Ok(self.popen.send_signal(libc::SIGHUP)?)
+            }
         }
 
         pub fn try_wait(&mut self) -> TogetherResult<Option<i32>> {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -41,7 +41,7 @@ pub struct Load {
 #[derive(Debug, clap::Parser)]
 pub struct Rerun {}
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, clap::Parser)]
+#[derive(Debug, Clone, clap::Parser)]
 pub struct Run {
     #[clap(
         last = true,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -102,6 +102,21 @@ impl Terminal {
             .unwrap()?;
         Some(&items[index])
     }
+    pub fn select_ordered<'a, T: std::fmt::Display>(
+        prompt: &'a str,
+        items: &'a [T],
+    ) -> Option<Vec<&'a T>> {
+        let mut opts_commands = vec![];
+        let sort = dialoguer::Sort::with_theme(&ColorfulTheme::default())
+            .with_prompt(prompt)
+            .items(items)
+            .interact_opt()
+            .unwrap()?;
+        for index in sort {
+            opts_commands.push(&items[index]);
+        }
+        Some(opts_commands)
+    }
     pub fn log(message: &str) {
         // print message with green colorized prefix
         println!("\x1b[32m[+]\x1b[0m {}", message);


### PR DESCRIPTION
run a set of commands sequentially on together startup

breaking change to config format, but now uses semver to communicate config changes to users in the future