### PR TITLE
Add aliases to command picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "together-rs"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "together-rs"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["Michael Lawrence <mblawrence27@gmail.com>"]

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -62,13 +62,13 @@ pub fn block_for_user_input(
                 log!("[status]");
                 match sender.list() {
                     Ok(list) => {
-t_println!("together is running {} commands in parallel:", list.len());
+                        t_println!("together is running {} commands in parallel:", list.len());
                         for command in list {
-t_println!("  {}", command);
+                            t_println!("  {}", command);
                         }
                     }
                     Err(_) => {
-t_println!("together is running in an unknown state");
+                        t_println!("together is running in an unknown state");
                     }
                 }
             }
@@ -119,15 +119,14 @@ t_println!("together is running in an unknown state");
                 }
             }
             Key::Char('t') => {
-                let all_commands = start_opts.config.start_options.as_commands();
-                let command = Terminal::select_single_item(
+                let command = Terminal::select_single_command(
                     "Pick command to run, or press 'q' to cancel",
                     &sender,
-                    &all_commands,
+                    &start_opts.config.start_options.commands,
                 )?;
                 if let Some(command) = command {
-                    sender.send(ProcessAction::Create(command.clone()))?;
-                    state.last_command = Some(command.clone());
+                    sender.send(ProcessAction::Create(command.to_string()))?;
+                    state.last_command = Some(command.to_string());
                 }
             }
             Key::Char('.') => {
@@ -154,7 +153,7 @@ t_println!("together is running in an unknown state");
             Key::Char('z') => {
                 let all_recipes = config::get_unique_recipes(&start_opts.config.start_options);
                 let all_recipes = all_recipes.into_iter().cloned().collect::<Vec<_>>();
-                let recipe = Terminal::select_single_item(
+                let recipe = Terminal::select_single_recipe(
                     "Select a recipe to start running, or press 'q' to cancel (note: this will stop all other commands)",
                     &sender,
                     &all_recipes,

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -178,8 +178,10 @@ pub fn block_for_user_input(
                     }
                 }
             }
+            Key::Char('\n') => {}
             Key::Char(c) => {
-                log_err!("Unknown command: {}", c);
+                log_err!("Unknown command: '{}'", c);
+                log!("Press 'h' or '?' for help");
             }
             _ => {}
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,15 @@ fn execute_startup_commands(
         .map(|c| c.as_str().to_string())
         .collect::<Vec<_>>();
 
+    let opts = manager::CreateOptions::default();
+    let opts = if config.start_options.quiet_startup {
+        opts.with_stderr_only()
+    } else {
+        opts
+    };
+
     for command in commands {
-        match sender.send(ProcessAction::Create(command.clone()))? {
+        match sender.send(ProcessAction::CreateAdvanced(command.clone(), opts.clone()))? {
             ProcessActionResponse::Created(id) => match sender.send(ProcessAction::Wait(id))? {
                 ProcessActionResponse::Waited(done) => {
                     done.recv()?;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -121,13 +121,20 @@ impl Terminal {
         prompt: &'a str,
         items: &'a [T],
     ) -> Option<&'a T> {
+        let index = Self::select_single_index(prompt, items)?;
+        Some(&items[index])
+    }
+    pub fn select_single_index<'a, T: std::fmt::Display>(
+        prompt: &'a str,
+        items: &'a [T],
+    ) -> Option<usize> {
         let index = dialoguer::Select::with_theme(&ColorfulTheme::default())
             .with_prompt(prompt)
             .items(items)
             .interact_opt()
             .map_err(map_dialoguer_err)
             .unwrap()?;
-        Some(&items[index])
+        Some(index)
     }
     pub fn select_ordered<'a, T: std::fmt::Display>(
         prompt: &'a str,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -20,6 +20,9 @@ pub struct TogetherArgs {
     #[clap(short, long, help = "Only run the startup commands.")]
     pub init_only: bool,
 
+    #[clap(short, long = "quiet", help = "Quiet mode for startup commands.")]
+    pub quiet_startup: bool,
+
     #[clap(
         short,
         long,


### PR DESCRIPTION
Allows user to select commands (using 't' key) with items labelled with the 'alias', where available.