### PR TITLE
Yaml Config Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "together-rs"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,13 +230,19 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
@@ -264,6 +276,16 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -359,6 +381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,18 +394,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -391,6 +419,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -482,6 +525,7 @@ dependencies = [
  "libc",
  "semver",
  "serde",
+ "serde_yml",
  "subprocess",
  "termion",
  "toml",
@@ -538,6 +582,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "together-rs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["Michael Lawrence <mblawrence27@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "5.0.1"
 libc = "0.2.153"
 semver = "1.0.22"
 serde = { version = "1.0.196", features = ["derive"] }
+serde_yml = "0.0.12"
 subprocess = "0.2.9"
 termion = { version = "4.0.2", optional = true }
 toml = "0.8.10"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternatively, `together` can be installed using the pre-built binaries for your
 
 ```sh
 # For example, on macOS
-curl -L https://github.com/michaelblawrence/together-rs/releases/download/0.3.0/together-rs_0.3.0_x86_64-apple-darwin.zip -o together.zip
+curl -L https://github.com/michaelblawrence/together-rs/releases/download/0.4.0/together-rs_0.4.0_x86_64-apple-darwin.zip -o together.zip
 unzip together.zip
 mv together /usr/local/bin
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ While the interactive prompt is running, you can manage the commands by pressing
 
 Every time you run `together`, it saves the configuration to local disk.
 
-You can use the `together load [toml_path]` option to specify a configuration file to use. Or use the following command to start `together` with the last saved configuration:
+You can use the `together load [yml_path]` option to specify a configuration file to use. Or use the following command to start `together` with the last saved configuration:
 
 ```sh
 together rerun

--- a/samples/together.detailed.toml
+++ b/samples/together.detailed.toml
@@ -1,5 +1,5 @@
 # This is a sample configuration file shows how to use `together` to handle a monorepo with multiple services
-version = "0.3.0"
+version = "0.4.0"
 
 # these commands will run sequentially on together startup
 startup = ["yarn", "prisma", "api-types"]
@@ -18,21 +18,21 @@ alias = "api-types"
 command = "yarn workspace api-types build"
 
 [[commands]]
-# this command will run once startup is complete (because of the `active` flag)
+# this command will run once startup is complete (because of the `default` flag)
 alias = "server"
 command = "yarn workspace server dev"
-recipes = ["server", "client", "event processor"]
-active = true
+recipes = ["server", "client", "processor"]
+default = true
 
 [[commands]]
 # this command will run at the same time as the command above
 alias = "client"
 command = "yarn workspace client start"
 recipes = ["client"]
-active = true
+default = true
 
 [[commands]]
 # not configured to run on startup or with together the other commands - though it can be triggered manually at any time
 alias = "event-processor"
 command = "yarn workspace event-processor dev"
-recipes = ["event processor"]
+recipes = ["processor"]

--- a/samples/together.detailed.yml
+++ b/samples/together.detailed.yml
@@ -1,0 +1,44 @@
+# This is a sample configuration file shows how to use `together` to handle a monorepo with multiple services
+version: 0.4.0
+
+# these commands will run sequentially on together startup
+startup:
+  - yarn
+  - prisma
+  - api-types
+
+# this is where you define your commands
+commands:
+  # configured above to run first on startup
+  - command: yarn
+
+  # configured above to run second on startup
+  - alias: prisma
+    command: yarn workspace api-types prisma generate
+
+  # this command will run third on startup (because of the `active` flag)
+  - alias: api-types
+    command: yarn workspace api-types build
+
+  # this command will run concurrently after startup is complete (because of the `default` flag)
+  - alias: server
+    command: yarn workspace server dev
+    recipes:
+      - server
+      - client
+      - processor
+    default: true
+
+  # this command will run concurrently after startup is complete (because of the `default` flag)
+  - alias: client
+    command: yarn workspace client start
+    recipes:
+      - client
+    default: true
+
+  # this command can be run manually using `together run --recipes processor` (this would start the server and event-processor)
+  # or can be run using the 't' key binding once together startup is complete
+  - alias: event-processor
+    command: yarn workspace event-processor dev
+    recipes:
+      - processor

--- a/src/config.rs
+++ b/src/config.rs
@@ -391,6 +391,7 @@ pub mod commands {
         Detailed {
             command: String,
             alias: Option<String>,
+            #[serde(alias = "default")]
             active: Option<bool>,
             recipes: Option<Vec<String>>,
         },

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ pub type TogetherResult<T> = std::result::Result<T, TogetherError>;
 #[derive(Debug)]
 pub enum TogetherError {
     Io(std::io::Error),
+    Yaml(serde_yml::Error),
     TomlSerialize(toml::ser::Error),
     TomlDeserialize(toml::de::Error),
     ChannelRecvError(mpsc::RecvError),
@@ -17,6 +18,7 @@ pub enum TogetherError {
 pub enum TogetherInternalError {
     ProcessFailedToExit,
     UnexpectedResponse,
+    InvalidConfigExtension,
 }
 
 impl std::fmt::Display for TogetherError {
@@ -24,6 +26,7 @@ impl std::fmt::Display for TogetherError {
         use TogetherInternalError as TIE;
         match self {
             TogetherError::Io(e) => write!(f, "IO error: {}", e),
+            TogetherError::Yaml(e) => write!(f, "YAML error: {}", e),
             TogetherError::TomlSerialize(e) => write!(f, "TOML serialization error: {}", e),
             TogetherError::TomlDeserialize(e) => write!(f, "TOML deserialization error: {}", e),
             TogetherError::ChannelRecvError(e) => write!(f, "Channel receive error: {}", e),
@@ -34,6 +37,9 @@ impl std::fmt::Display for TogetherError {
             TogetherError::InternalError(TIE::UnexpectedResponse) => {
                 write!(f, "Unexpected response from process")
             }
+            TogetherError::InternalError(TIE::InvalidConfigExtension) => {
+                write!(f, "Invalid configuration file extension")
+            }
             TogetherError::DynError(e) => write!(f, "Error: {}", e),
         }
     }
@@ -43,6 +49,7 @@ impl std::error::Error for TogetherError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             TogetherError::Io(e) => Some(e),
+            TogetherError::Yaml(e) => Some(e),
             TogetherError::TomlSerialize(e) => Some(e),
             TogetherError::TomlDeserialize(e) => Some(e),
             TogetherError::ChannelRecvError(e) => Some(e),
@@ -56,6 +63,12 @@ impl std::error::Error for TogetherError {
 impl From<std::io::Error> for TogetherError {
     fn from(e: std::io::Error) -> Self {
         TogetherError::Io(e)
+    }
+}
+
+impl From<serde_yml::Error> for TogetherError {
+    fn from(e: serde_yml::Error) -> Self {
+        TogetherError::Yaml(e)
     }
 }
 

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -248,10 +248,12 @@ fn handle_key_press(
             }
         }
         Key::Char('t') => {
-            let command = Terminal::select_single_command(
+            let list = sender.list()?;
+            let command = Terminal::select_single_command_with_running(
                 "Pick command to run, or press 'q' to cancel",
                 &sender,
                 &start_opts.config.start_options.commands,
+                &list,
             )?;
             if let Some(command) = command {
                 sender.spawn(command)?;


### PR DESCRIPTION
- Support YAML for together config files (TOML is still supported as well)
- Advanced controls to kill process using 'K' key to choose between SIGINT, SIGTERM and SIGKILL
- New control to redo the last command action to start or restart a given command (using the '.' key)